### PR TITLE
Implement authenticated profile loading

### DIFF
--- a/app/src/main/java/com/mayank/superapp/MainActivity.kt
+++ b/app/src/main/java/com/mayank/superapp/MainActivity.kt
@@ -41,6 +41,7 @@ class MainActivity : AppCompatActivity() {
         fusedLocationClient = LocationServices.getFusedLocationProviderClient(this)
 
         preferencesHelper = PreferencesHelper(this)
+        RetrofitClient.setPreferencesHelper(preferencesHelper)
 
         // Check if user is logged in
         if (!preferencesHelper.isLoggedIn()) {
@@ -62,6 +63,7 @@ class MainActivity : AppCompatActivity() {
                 R.id.nav_profile -> {
                     binding.scrollContent.visibility = View.GONE
                     findViewById<View>(R.id.profileTab).visibility = View.VISIBLE
+                    loadUserProfile()
                     true
                 }
                 else -> {
@@ -337,6 +339,19 @@ class MainActivity : AppCompatActivity() {
         cardView.addView(cardContent)
 
         return cardView
+    }
+
+    private fun loadUserProfile() {
+        lifecycleScope.launch {
+            try {
+                val user = RetrofitClient.userService.getCurrentUser()
+                findViewById<TextView>(R.id.tvName)?.text = user.name
+                findViewById<TextView>(R.id.tvEmail)?.text = user.email
+            } catch (e: Exception) {
+                e.printStackTrace()
+                Toast.makeText(this@MainActivity, "Failed to load profile", Toast.LENGTH_SHORT).show()
+            }
+        }
     }
 
     private fun createCircleDrawable(color: String): GradientDrawable {

--- a/app/src/main/java/com/mayank/superapp/UserDto.kt
+++ b/app/src/main/java/com/mayank/superapp/UserDto.kt
@@ -1,0 +1,10 @@
+package com.mayank.superapp
+
+/**
+ * Simple DTO representing a user profile returned from the API.
+ */
+data class UserDto(
+    val id: String,
+    val email: String,
+    val name: String
+)

--- a/app/src/main/java/com/mayank/superapp/UserService.kt
+++ b/app/src/main/java/com/mayank/superapp/UserService.kt
@@ -1,0 +1,14 @@
+package com.mayank.superapp
+
+import retrofit2.http.GET
+
+/**
+ * Retrofit service for user related endpoints.
+ */
+interface UserService {
+    /**
+     * Fetch the profile of the currently authenticated user.
+     */
+    @GET("user/me")
+    suspend fun getCurrentUser(): UserDto
+}

--- a/app/src/main/res/layout/layout_profile_tab.xml
+++ b/app/src/main/res/layout/layout_profile_tab.xml
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:gravity="center"
     android:padding="24dp">
 
     <TextView
@@ -13,12 +12,40 @@
         android:text="Profile"
         android:textSize="24sp"
         android:textStyle="bold"
-        android:paddingBottom="16dp" />
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <TextView
+        android:id="@+id/tvName"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Name"
+        android:textSize="18sp"
+        android:layout_marginTop="32dp"
+        app:layout_constraintTop_toBottomOf="@id/tvProfileTitle"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
+
+    <TextView
+        android:id="@+id/tvEmail"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:text="Email"
+        android:textSize="16sp"
+        android:layout_marginTop="8dp"
+        app:layout_constraintTop_toBottomOf="@id/tvName"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
 
     <Button
         android:id="@+id/btnLogout"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Logout" />
+        android:text="Logout"
+        android:layout_marginTop="32dp"
+        app:layout_constraintTop_toBottomOf="@id/tvEmail"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"/>
 
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
## Summary
- add `UserDto` and a `UserService` for profile endpoints
- attach auth tokens in `RetrofitClient` requests
- fetch profile info when opening the Profile tab
- display name and email in the Profile screen using a new layout

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf71d5a44832a9f85a2822cc7353a