### PR TITLE
Add fallback sample data for representatives

### DIFF
--- a/app/src/main/java/com/mayank/superapp/SittingMember.kt
+++ b/app/src/main/java/com/mayank/superapp/SittingMember.kt
@@ -11,5 +11,6 @@ data class SittingMember(
     val lokSabhaTerms: Int,
     val district: String?,
     val latitude: Double?,
-    val longitude: Double?
+    val longitude: Double?,
+    val designation: String? = null
 )


### PR DESCRIPTION
## Summary
- provide new `designation` field in `SittingMember`
- add mock representative list in `MainActivity`
- fallback to the mock list when API calls fail or return empty
- inflate `view_rep_card.xml` for consistent styling

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c01d7c334832a825b3d0f4b5674c1