### PR TITLE
Store email after login

### DIFF
--- a/app/src/main/java/com/mayank/superapp/LoginActivity.kt
+++ b/app/src/main/java/com/mayank/superapp/LoginActivity.kt
@@ -114,6 +114,8 @@ class LoginActivity : AppCompatActivity() {
                     response.body()?.data?.let { jwt ->
                         Log.d(TAG, "Auth OK – User: ${jwt.user.email}")
                         preferencesHelper.saveAuthToken(jwt.accessToken)
+                        preferencesHelper.saveUserEmail(jwt.user.email)
+                        preferencesHelper.saveUserName(jwt.user.name)
                         navigateToMain()
                     } ?: run {
                         Toast.makeText(this@LoginActivity, "Empty payload", Toast.LENGTH_SHORT).show()

--- a/app/src/main/java/com/mayank/superapp/MainActivity.kt
+++ b/app/src/main/java/com/mayank/superapp/MainActivity.kt
@@ -279,6 +279,9 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun loadUserProfile() {
+        findViewById<TextView>(R.id.tvEmail)?.text = preferencesHelper.getUserEmail()
+        findViewById<TextView>(R.id.tvName)?.text = preferencesHelper.getUserName()
+
         lifecycleScope.launch {
             try {
                 val user = RetrofitClient.userService.getCurrentUser()

--- a/app/src/main/java/com/mayank/superapp/PreferencesHelper.kt
+++ b/app/src/main/java/com/mayank/superapp/PreferencesHelper.kt
@@ -22,4 +22,20 @@ class PreferencesHelper(context: Context) {
     fun isLoggedIn(): Boolean {
         return getAuthToken() != null
     }
+
+    fun saveUserEmail(email: String) {
+        prefs.edit().putString("user_email", email).apply()
+    }
+
+    fun getUserEmail(): String? {
+        return prefs.getString("user_email", null)
+    }
+
+    fun saveUserName(name: String) {
+        prefs.edit().putString("user_name", name).apply()
+    }
+
+    fun getUserName(): String? {
+        return prefs.getString("user_name", null)
+    }
 }


### PR DESCRIPTION
## Summary
- extend PreferencesHelper with email/name storage helpers
- persist the user email & name when login succeeds
- show stored profile details on the profile screen

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c070b0e1c832ab684eeff67f63eed