### PR TITLE
Implement skeleton for issues and services

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,19 @@
             android:exported="false" />
 
         <activity
+            android:name="com.mayank.superapp.issues.IssuesActivity"
+            android:exported="false" />
+        <activity
+            android:name="com.mayank.superapp.issues.IssueDetailActivity"
+            android:exported="false" />
+        <activity
+            android:name="com.mayank.superapp.services.ServicesActivity"
+            android:exported="false" />
+        <activity
+            android:name="com.mayank.superapp.services.ServiceDetailActivity"
+            android:exported="false" />
+
+        <activity
             android:name=".MainActivity"
             android:exported="true">
             <intent-filter>

--- a/app/src/main/java/com/mayank/superapp/MainActivity.kt
+++ b/app/src/main/java/com/mayank/superapp/MainActivity.kt
@@ -22,6 +22,7 @@ import com.google.android.gms.location.LocationServices
 import com.mayank.superapp.RetrofitClient
 import com.mayank.superapp.SittingMember
 import com.mayank.superapp.databinding.ActivityMainBinding
+import androidx.fragment.app.Fragment
 import kotlinx.coroutines.launch
 import android.view.LayoutInflater
 import android.graphics.drawable.GradientDrawable
@@ -32,6 +33,9 @@ class MainActivity : AppCompatActivity() {
     private lateinit var preferencesHelper: PreferencesHelper
     private lateinit var googleSignInClient: GoogleSignInClient
     private lateinit var fusedLocationClient: FusedLocationProviderClient
+
+    private val issuesFragment = com.mayank.superapp.issues.IssuesFragment()
+    private val servicesFragment = com.mayank.superapp.services.ServicesFragment()
 
     private var currentLatitude: Double = 0.0
     private var currentLongitude: Double = 0.0
@@ -107,22 +111,19 @@ class MainActivity : AppCompatActivity() {
         binding.bottomNav.setOnItemSelectedListener { item ->
             when (item.itemId) {
                 R.id.nav_profile -> {
-                    binding.scrollContent.visibility = View.GONE
-                    findViewById<View>(R.id.profileTab).visibility = View.VISIBLE
-                    loadUserProfile()
+                    showProfile()
                     true
                 }
                 R.id.nav_issues -> {
-                    startActivity(Intent(this, com.mayank.superapp.issues.IssuesActivity::class.java))
+                    showFragment(issuesFragment)
                     true
                 }
                 R.id.nav_services -> {
-                    startActivity(Intent(this, com.mayank.superapp.services.ServicesActivity::class.java))
+                    showFragment(servicesFragment)
                     true
                 }
                 else -> {
-                    findViewById<View>(R.id.profileTab).visibility = View.GONE
-                    binding.scrollContent.visibility = View.VISIBLE
+                    showOfficials()
                     true
                 }
             }
@@ -329,5 +330,27 @@ class MainActivity : AppCompatActivity() {
         val intent = Intent(this, LoginActivity::class.java)
         startActivity(intent)
         finish()
+    }
+
+    private fun showProfile() {
+        binding.fragmentContainer.visibility = View.GONE
+        binding.scrollContent.visibility = View.GONE
+        findViewById<View>(R.id.profileTab).visibility = View.VISIBLE
+        loadUserProfile()
+    }
+
+    private fun showOfficials() {
+        binding.fragmentContainer.visibility = View.GONE
+        findViewById<View>(R.id.profileTab).visibility = View.GONE
+        binding.scrollContent.visibility = View.VISIBLE
+    }
+
+    private fun showFragment(fragment: androidx.fragment.app.Fragment) {
+        findViewById<View>(R.id.profileTab).visibility = View.GONE
+        binding.scrollContent.visibility = View.GONE
+        binding.fragmentContainer.visibility = View.VISIBLE
+        supportFragmentManager.beginTransaction()
+            .replace(R.id.fragmentContainer, fragment)
+            .commit()
     }
 }

--- a/app/src/main/java/com/mayank/superapp/MainActivity.kt
+++ b/app/src/main/java/com/mayank/superapp/MainActivity.kt
@@ -112,6 +112,14 @@ class MainActivity : AppCompatActivity() {
                     loadUserProfile()
                     true
                 }
+                R.id.nav_issues -> {
+                    startActivity(Intent(this, com.mayank.superapp.issues.IssuesActivity::class.java))
+                    true
+                }
+                R.id.nav_services -> {
+                    startActivity(Intent(this, com.mayank.superapp.services.ServicesActivity::class.java))
+                    true
+                }
                 else -> {
                     findViewById<View>(R.id.profileTab).visibility = View.GONE
                     binding.scrollContent.visibility = View.VISIBLE
@@ -217,6 +225,12 @@ class MainActivity : AppCompatActivity() {
                 displayRepresentatives(sampleMembers)
             }
         }
+    }
+
+    override fun onResume() {
+        super.onResume()
+        // ensure the main tab is highlighted when returning from other screens
+        binding.bottomNav.selectedItemId = R.id.nav_officials
     }
 
     private fun updateConstituencyDisplay(constituency: String) {

--- a/app/src/main/java/com/mayank/superapp/issues/IssueAdapter.kt
+++ b/app/src/main/java/com/mayank/superapp/issues/IssueAdapter.kt
@@ -26,6 +26,7 @@ class IssueAdapter(
         fun bind(item: Issue) {
             binding.tvTitle.text = item.title
             binding.tvStatus.text = item.status.name
+            binding.tvReporter.text = item.reporterName
             binding.root.setOnClickListener { onClick(item) }
         }
     }

--- a/app/src/main/java/com/mayank/superapp/issues/IssueAdapter.kt
+++ b/app/src/main/java/com/mayank/superapp/issues/IssueAdapter.kt
@@ -1,0 +1,37 @@
+package com.mayank.superapp.issues
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.mayank.superapp.databinding.ItemIssueBinding
+
+/** Adapter for issues list */
+class IssueAdapter(
+    private val onClick: (Issue) -> Unit
+) : ListAdapter<Issue, IssueAdapter.IssueViewHolder>(DiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): IssueViewHolder {
+        val binding = ItemIssueBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return IssueViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: IssueViewHolder, position: Int) {
+        val issue = getItem(position)
+        holder.bind(issue)
+    }
+
+    inner class IssueViewHolder(private val binding: ItemIssueBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: Issue) {
+            binding.tvTitle.text = item.title
+            binding.tvStatus.text = item.status.name
+            binding.root.setOnClickListener { onClick(item) }
+        }
+    }
+
+    companion object DiffCallback : DiffUtil.ItemCallback<Issue>() {
+        override fun areItemsTheSame(oldItem: Issue, newItem: Issue): Boolean = oldItem.id == newItem.id
+        override fun areContentsTheSame(oldItem: Issue, newItem: Issue): Boolean = oldItem == newItem
+    }
+}

--- a/app/src/main/java/com/mayank/superapp/issues/IssueAdapter.kt
+++ b/app/src/main/java/com/mayank/superapp/issues/IssueAdapter.kt
@@ -27,6 +27,9 @@ class IssueAdapter(
             binding.tvTitle.text = item.title
             binding.tvStatus.text = item.status.name
             binding.tvReporter.text = item.reporterName
+            binding.tvHandler.text = "Handled by ${item.handler}"
+            binding.tvUpvotes.text = item.upvotes.toString()
+            binding.tvDownvotes.text = item.downvotes.toString()
             binding.root.setOnClickListener { onClick(item) }
         }
     }

--- a/app/src/main/java/com/mayank/superapp/issues/IssueDetailActivity.kt
+++ b/app/src/main/java/com/mayank/superapp/issues/IssueDetailActivity.kt
@@ -1,0 +1,23 @@
+package com.mayank.superapp.issues
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.mayank.superapp.databinding.ActivityIssueDetailBinding
+
+class IssueDetailActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityIssueDetailBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityIssueDetailBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        val id = intent.getStringExtra(EXTRA_ID)
+        binding.tvDetail.text = id ?: "Unknown"
+    }
+
+    companion object {
+        const val EXTRA_ID = "issue_id"
+    }
+}

--- a/app/src/main/java/com/mayank/superapp/issues/IssueModels.kt
+++ b/app/src/main/java/com/mayank/superapp/issues/IssueModels.kt
@@ -48,5 +48,7 @@ data class Issue(
     val images: List<String> = emptyList(),
     val distance: Float = Random.nextFloat() * 10f,
     val isFollowing: Boolean = false,
-    val hasUpvoted: Boolean = false
+    val hasUpvoted: Boolean = false,
+    /** Which representative will handle this issue */
+    val handler: String
 )

--- a/app/src/main/java/com/mayank/superapp/issues/IssueModels.kt
+++ b/app/src/main/java/com/mayank/superapp/issues/IssueModels.kt
@@ -1,0 +1,52 @@
+package com.mayank.superapp.issues
+
+import java.util.UUID
+import kotlin.random.Random
+
+/** Simple location representation */
+data class GeoLocation(
+    val latitude: Double,
+    val longitude: Double
+)
+
+/** Priority levels for issues */
+enum class Priority { LOW, MEDIUM, HIGH, CRITICAL }
+
+/** Status of an issue */
+enum class IssueStatus { PENDING, ACKNOWLEDGED, IN_PROGRESS, RESOLVED, CLOSED }
+
+/** Category of issue with icon and color resource id */
+enum class IssueCategory(val icon: Int, val color: Int) {
+    ROADS(android.R.drawable.ic_menu_compass, android.R.color.darker_gray),
+    WATER(android.R.drawable.ic_menu_compass, android.R.color.holo_blue_light),
+    ELECTRICITY(android.R.drawable.ic_menu_compass, android.R.color.holo_orange_light),
+    WASTE(android.R.drawable.ic_menu_compass, android.R.color.holo_green_dark),
+    SAFETY(android.R.drawable.ic_menu_compass, android.R.color.holo_red_dark),
+    PARKS(android.R.drawable.ic_menu_compass, android.R.color.holo_green_light),
+    OTHER(android.R.drawable.ic_menu_help, android.R.color.darker_gray)
+}
+
+/** Main Issue model */
+data class Issue(
+    val id: String = UUID.randomUUID().toString(),
+    val title: String,
+    val description: String,
+    val category: IssueCategory,
+    val status: IssueStatus,
+    val priority: Priority,
+    val location: GeoLocation,
+    val reporterId: String,
+    val reporterName: String,
+    val reporterAvatar: String?,
+    val assignedTo: String? = null,
+    val assignedToName: String? = null,
+    val createdAt: Long = System.currentTimeMillis(),
+    val updatedAt: Long = System.currentTimeMillis(),
+    val upvotes: Int = Random.nextInt(0, 1000),
+    val downvotes: Int = Random.nextInt(0, 100),
+    val comments: Int = Random.nextInt(0, 50),
+    val images: List<String> = emptyList(),
+    val distance: Float = Random.nextFloat() * 10f,
+    val isFollowing: Boolean = false,
+    val hasUpvoted: Boolean = false
+)

--- a/app/src/main/java/com/mayank/superapp/issues/IssuesActivity.kt
+++ b/app/src/main/java/com/mayank/superapp/issues/IssuesActivity.kt
@@ -20,6 +20,9 @@ class IssuesActivity : AppCompatActivity() {
         binding = ActivityIssuesBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        setSupportActionBar(binding.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
         adapter = IssueAdapter { issue ->
             val intent = Intent(this, IssueDetailActivity::class.java)
             intent.putExtra(IssueDetailActivity.EXTRA_ID, issue.id)
@@ -37,5 +40,13 @@ class IssuesActivity : AppCompatActivity() {
                 binding.swipeRefresh.isRefreshing = state.loading
             }
         }
+    }
+
+    override fun onOptionsItemSelected(item: android.view.MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            finish()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
     }
 }

--- a/app/src/main/java/com/mayank/superapp/issues/IssuesActivity.kt
+++ b/app/src/main/java/com/mayank/superapp/issues/IssuesActivity.kt
@@ -1,0 +1,41 @@
+package com.mayank.superapp.issues
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.mayank.superapp.databinding.ActivityIssuesBinding
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.flow.collectLatest
+
+class IssuesActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityIssuesBinding
+    private val viewModel: IssuesViewModel by viewModels()
+    private lateinit var adapter: IssueAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityIssuesBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        adapter = IssueAdapter { issue ->
+            val intent = Intent(this, IssueDetailActivity::class.java)
+            intent.putExtra(IssueDetailActivity.EXTRA_ID, issue.id)
+            startActivity(intent)
+        }
+
+        binding.recyclerView.layoutManager = LinearLayoutManager(this)
+        binding.recyclerView.adapter = adapter
+
+        binding.swipeRefresh.setOnRefreshListener { viewModel.loadIssues() }
+
+        lifecycleScope.launchWhenStarted {
+            viewModel.uiState.collectLatest { state ->
+                adapter.submitList(state.issues)
+                binding.swipeRefresh.isRefreshing = state.loading
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/mayank/superapp/issues/IssuesFragment.kt
+++ b/app/src/main/java/com/mayank/superapp/issues/IssuesFragment.kt
@@ -1,0 +1,48 @@
+package com.mayank.superapp.issues
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.mayank.superapp.R
+import com.mayank.superapp.databinding.FragmentIssuesBinding
+import kotlinx.coroutines.flow.collectLatest
+
+class IssuesFragment : Fragment(R.layout.fragment_issues) {
+
+    private var _binding: FragmentIssuesBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel: IssuesViewModel by viewModels()
+    private lateinit var adapter: IssueAdapter
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        _binding = FragmentIssuesBinding.bind(view)
+
+        adapter = IssueAdapter { issue ->
+            val intent = Intent(requireContext(), IssueDetailActivity::class.java)
+            intent.putExtra(IssueDetailActivity.EXTRA_ID, issue.id)
+            startActivity(intent)
+        }
+
+        binding.recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        binding.recyclerView.adapter = adapter
+
+        binding.swipeRefresh.setOnRefreshListener { viewModel.loadIssues() }
+
+        lifecycleScope.launchWhenStarted {
+            viewModel.uiState.collectLatest { state ->
+                adapter.submitList(state.issues)
+                binding.swipeRefresh.isRefreshing = state.loading
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/mayank/superapp/issues/IssuesRepository.kt
+++ b/app/src/main/java/com/mayank/superapp/issues/IssuesRepository.kt
@@ -1,0 +1,14 @@
+package com.mayank.superapp.issues
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+
+/** Simple repository returning mock issues */
+class IssuesRepository {
+    /** Simulate network load with delay */
+    suspend fun fetchIssues(): List<Issue> = withContext(Dispatchers.IO) {
+        delay(500)
+        MockIssueGenerator.generate()
+    }
+}

--- a/app/src/main/java/com/mayank/superapp/issues/IssuesViewModel.kt
+++ b/app/src/main/java/com/mayank/superapp/issues/IssuesViewModel.kt
@@ -1,0 +1,39 @@
+package com.mayank.superapp.issues
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+/** ViewModel exposing UI state for the issues screen */
+class IssuesViewModel(
+    private val repository: IssuesRepository = IssuesRepository()
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<IssuesUiState>(IssuesUiState())
+    val uiState: StateFlow<IssuesUiState> = _uiState.asStateFlow()
+
+    init {
+        loadIssues()
+    }
+
+    fun loadIssues() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(loading = true)
+            try {
+                val issues = repository.fetchIssues()
+                _uiState.value = IssuesUiState(issues = issues, loading = false)
+            } catch (t: Throwable) {
+                _uiState.value = IssuesUiState(error = t.localizedMessage)
+            }
+        }
+    }
+}
+
+data class IssuesUiState(
+    val issues: List<Issue> = emptyList(),
+    val loading: Boolean = false,
+    val error: String? = null
+)

--- a/app/src/main/java/com/mayank/superapp/issues/MockIssueGenerator.kt
+++ b/app/src/main/java/com/mayank/superapp/issues/MockIssueGenerator.kt
@@ -1,0 +1,44 @@
+package com.mayank.superapp.issues
+
+import kotlin.random.Random
+
+/** Helper object to create mock issues for demos */
+object MockIssueGenerator {
+    fun generate(count: Int = 20): List<Issue> {
+        val titles = listOf(
+            "Pothole on Main Street needs urgent repair",
+            "Street light not working near Park Avenue",
+            "Garbage not collected for 3 days",
+            "Water leakage from main pipeline",
+            "Illegal parking blocking emergency exit",
+            "Park maintenance required - broken swings",
+            "Power outage in Sector 5",
+            "Damaged road divider causing accidents"
+        )
+
+        val reporters = listOf(
+            "Rahul Sharma", "Priya Patel", "Amit Kumar",
+            "Sneha Gupta", "Raj Singh", "Anita Verma"
+        )
+
+        return List(count) { index ->
+            Issue(
+                title = titles.random(),
+                description = "Detailed description of the issue...",
+                category = IssueCategory.values().random(),
+                status = IssueStatus.values().random(),
+                priority = Priority.values().random(),
+                location = GeoLocation(
+                    28.5355 + Random.nextDouble() * 0.1,
+                    77.3910 + Random.nextDouble() * 0.1
+                ),
+                reporterId = "user_${Random.nextInt(1000)}",
+                reporterName = reporters.random(),
+                reporterAvatar = "https://i.pravatar.cc/150?img=${Random.nextInt(70)}",
+                images = if (Random.nextBoolean())
+                    listOf("https://picsum.photos/400/300?random=$index")
+                else emptyList()
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/mayank/superapp/issues/MockIssueGenerator.kt
+++ b/app/src/main/java/com/mayank/superapp/issues/MockIssueGenerator.kt
@@ -21,6 +21,8 @@ object MockIssueGenerator {
             "Sneha Gupta", "Raj Singh", "Anita Verma"
         )
 
+        val handlers = listOf("MP", "MLA", "DM")
+
         return List(count) { index ->
             Issue(
                 title = titles.random(),
@@ -37,7 +39,8 @@ object MockIssueGenerator {
                 reporterAvatar = "https://i.pravatar.cc/150?img=${Random.nextInt(70)}",
                 images = if (Random.nextBoolean())
                     listOf("https://picsum.photos/400/300?random=$index")
-                else emptyList()
+                else emptyList(),
+                handler = handlers.random()
             )
         }
     }

--- a/app/src/main/java/com/mayank/superapp/services/MockServiceGenerator.kt
+++ b/app/src/main/java/com/mayank/superapp/services/MockServiceGenerator.kt
@@ -2,14 +2,24 @@ package com.mayank.superapp.services
 
 /** Generates mock services list */
 object MockServiceGenerator {
-    fun generate(count: Int = 20): List<Service> = List(count) {
+    private val names = listOf(
+        "Apply for Birth Certificate",
+        "Renew Driving License",
+        "Water Connection Request",
+        "Electricity Bill Payment",
+        "Passport Application",
+        "Property Tax Payment"
+    )
+
+    fun generate(count: Int = 20): List<Service> = List(count) { index ->
+        val title = names.random()
         Service(
-            name = "Service $it",
-            description = "Description for service $it",
+            name = title,
+            description = "Information regarding $title",
             department = Department.values().random(),
             category = ServiceCategory.values().random(),
             isOnline = listOf(true, false).random(),
-            fee = if (it % 3 == 0) 100.0 else null,
+            fee = if (index % 3 == 0) 100.0 else null,
             processingTime = "3-5 days",
             requiredDocuments = listOf(Document("ID Proof")),
             eligibilityCriteria = listOf("Citizen"),

--- a/app/src/main/java/com/mayank/superapp/services/MockServiceGenerator.kt
+++ b/app/src/main/java/com/mayank/superapp/services/MockServiceGenerator.kt
@@ -1,0 +1,19 @@
+package com.mayank.superapp.services
+
+/** Generates mock services list */
+object MockServiceGenerator {
+    fun generate(count: Int = 20): List<Service> = List(count) {
+        Service(
+            name = "Service $it",
+            description = "Description for service $it",
+            department = Department.values().random(),
+            category = ServiceCategory.values().random(),
+            isOnline = listOf(true, false).random(),
+            fee = if (it % 3 == 0) 100.0 else null,
+            processingTime = "3-5 days",
+            requiredDocuments = listOf(Document("ID Proof")),
+            eligibilityCriteria = listOf("Citizen"),
+            process = listOf(ProcessStep("Submit form"))
+        )
+    }
+}

--- a/app/src/main/java/com/mayank/superapp/services/ServiceAdapter.kt
+++ b/app/src/main/java/com/mayank/superapp/services/ServiceAdapter.kt
@@ -23,6 +23,8 @@ class ServiceAdapter(
     inner class ServiceViewHolder(private val binding: ItemServiceBinding) : RecyclerView.ViewHolder(binding.root) {
         fun bind(item: Service) {
             binding.tvName.text = item.name
+            binding.tvDepartment.text = item.department.name
+            binding.tvDesc.text = item.description
             binding.root.setOnClickListener { onClick(item) }
         }
     }

--- a/app/src/main/java/com/mayank/superapp/services/ServiceAdapter.kt
+++ b/app/src/main/java/com/mayank/superapp/services/ServiceAdapter.kt
@@ -1,0 +1,34 @@
+package com.mayank.superapp.services
+
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.mayank.superapp.databinding.ItemServiceBinding
+
+class ServiceAdapter(
+    private val onClick: (Service) -> Unit
+) : ListAdapter<Service, ServiceAdapter.ServiceViewHolder>(DiffCallback) {
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ServiceViewHolder {
+        val binding = ItemServiceBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        return ServiceViewHolder(binding)
+    }
+
+    override fun onBindViewHolder(holder: ServiceViewHolder, position: Int) {
+        holder.bind(getItem(position))
+    }
+
+    inner class ServiceViewHolder(private val binding: ItemServiceBinding) : RecyclerView.ViewHolder(binding.root) {
+        fun bind(item: Service) {
+            binding.tvName.text = item.name
+            binding.root.setOnClickListener { onClick(item) }
+        }
+    }
+
+    companion object DiffCallback : DiffUtil.ItemCallback<Service>() {
+        override fun areItemsTheSame(oldItem: Service, newItem: Service): Boolean = oldItem.id == newItem.id
+        override fun areContentsTheSame(oldItem: Service, newItem: Service): Boolean = oldItem == newItem
+    }
+}

--- a/app/src/main/java/com/mayank/superapp/services/ServiceDetailActivity.kt
+++ b/app/src/main/java/com/mayank/superapp/services/ServiceDetailActivity.kt
@@ -1,0 +1,23 @@
+package com.mayank.superapp.services
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.mayank.superapp.databinding.ActivityServiceDetailBinding
+
+class ServiceDetailActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityServiceDetailBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityServiceDetailBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        val id = intent.getStringExtra(EXTRA_ID)
+        binding.tvDetail.text = id ?: "Unknown"
+    }
+
+    companion object {
+        const val EXTRA_ID = "service_id"
+    }
+}

--- a/app/src/main/java/com/mayank/superapp/services/ServiceModels.kt
+++ b/app/src/main/java/com/mayank/superapp/services/ServiceModels.kt
@@ -1,0 +1,36 @@
+package com.mayank.superapp.services
+
+import java.util.UUID
+import kotlin.random.Random
+
+/** Simple document model */
+data class Document(
+    val name: String
+)
+
+/** Step in the process */
+data class ProcessStep(
+    val description: String
+)
+
+enum class ServiceCategory { GENERAL, HEALTH, TRANSPORT, EDUCATION }
+
+enum class Department { ADMINISTRATION, POLICE, FINANCE, HEALTH }
+
+/** Service model */
+data class Service(
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val description: String,
+    val department: Department,
+    val category: ServiceCategory,
+    val isOnline: Boolean,
+    val fee: Double?,
+    val processingTime: String,
+    val requiredDocuments: List<Document>,
+    val eligibilityCriteria: List<String>,
+    val process: List<ProcessStep>,
+    val popularityScore: Int = Random.nextInt(0, 100),
+    val averageRating: Float = Random.nextDouble(1.0, 5.0).toFloat(),
+    val totalReviews: Int = Random.nextInt(0, 1000)
+)

--- a/app/src/main/java/com/mayank/superapp/services/ServicesActivity.kt
+++ b/app/src/main/java/com/mayank/superapp/services/ServicesActivity.kt
@@ -1,0 +1,41 @@
+package com.mayank.superapp.services
+
+import android.content.Intent
+import android.os.Bundle
+import androidx.activity.viewModels
+import androidx.appcompat.app.AppCompatActivity
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.mayank.superapp.databinding.ActivityServicesBinding
+import kotlinx.coroutines.flow.collectLatest
+
+class ServicesActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityServicesBinding
+    private val viewModel: ServicesViewModel by viewModels()
+    private lateinit var adapter: ServiceAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityServicesBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        adapter = ServiceAdapter { service ->
+            val intent = Intent(this, ServiceDetailActivity::class.java)
+            intent.putExtra(ServiceDetailActivity.EXTRA_ID, service.id)
+            startActivity(intent)
+        }
+
+        binding.recyclerView.layoutManager = LinearLayoutManager(this)
+        binding.recyclerView.adapter = adapter
+
+        binding.swipeRefresh.setOnRefreshListener { viewModel.loadServices() }
+
+        lifecycleScope.launchWhenStarted {
+            viewModel.uiState.collectLatest { state ->
+                adapter.submitList(state.services)
+                binding.swipeRefresh.isRefreshing = state.loading
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/mayank/superapp/services/ServicesActivity.kt
+++ b/app/src/main/java/com/mayank/superapp/services/ServicesActivity.kt
@@ -20,6 +20,9 @@ class ServicesActivity : AppCompatActivity() {
         binding = ActivityServicesBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
+        setSupportActionBar(binding.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
         adapter = ServiceAdapter { service ->
             val intent = Intent(this, ServiceDetailActivity::class.java)
             intent.putExtra(ServiceDetailActivity.EXTRA_ID, service.id)
@@ -37,5 +40,13 @@ class ServicesActivity : AppCompatActivity() {
                 binding.swipeRefresh.isRefreshing = state.loading
             }
         }
+    }
+
+    override fun onOptionsItemSelected(item: android.view.MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            finish()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
     }
 }

--- a/app/src/main/java/com/mayank/superapp/services/ServicesFragment.kt
+++ b/app/src/main/java/com/mayank/superapp/services/ServicesFragment.kt
@@ -1,0 +1,48 @@
+package com.mayank.superapp.services
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.viewModels
+import androidx.lifecycle.lifecycleScope
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.mayank.superapp.R
+import com.mayank.superapp.databinding.FragmentServicesBinding
+import kotlinx.coroutines.flow.collectLatest
+
+class ServicesFragment : Fragment(R.layout.fragment_services) {
+
+    private var _binding: FragmentServicesBinding? = null
+    private val binding get() = _binding!!
+    private val viewModel: ServicesViewModel by viewModels()
+    private lateinit var adapter: ServiceAdapter
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        _binding = FragmentServicesBinding.bind(view)
+
+        adapter = ServiceAdapter { service ->
+            val intent = Intent(requireContext(), ServiceDetailActivity::class.java)
+            intent.putExtra(ServiceDetailActivity.EXTRA_ID, service.id)
+            startActivity(intent)
+        }
+
+        binding.recyclerView.layoutManager = LinearLayoutManager(requireContext())
+        binding.recyclerView.adapter = adapter
+
+        binding.swipeRefresh.setOnRefreshListener { viewModel.loadServices() }
+
+        lifecycleScope.launchWhenStarted {
+            viewModel.uiState.collectLatest { state ->
+                adapter.submitList(state.services)
+                binding.swipeRefresh.isRefreshing = state.loading
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/app/src/main/java/com/mayank/superapp/services/ServicesRepository.kt
+++ b/app/src/main/java/com/mayank/superapp/services/ServicesRepository.kt
@@ -1,0 +1,12 @@
+package com.mayank.superapp.services
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+
+class ServicesRepository {
+    suspend fun fetchServices(): List<Service> = withContext(Dispatchers.IO) {
+        delay(500)
+        MockServiceGenerator.generate()
+    }
+}

--- a/app/src/main/java/com/mayank/superapp/services/ServicesViewModel.kt
+++ b/app/src/main/java/com/mayank/superapp/services/ServicesViewModel.kt
@@ -1,0 +1,36 @@
+package com.mayank.superapp.services
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class ServicesViewModel(
+    private val repository: ServicesRepository = ServicesRepository()
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(ServicesUiState())
+    val uiState: StateFlow<ServicesUiState> = _uiState.asStateFlow()
+
+    init { loadServices() }
+
+    fun loadServices() {
+        viewModelScope.launch {
+            _uiState.value = _uiState.value.copy(loading = true)
+            try {
+                val data = repository.fetchServices()
+                _uiState.value = ServicesUiState(services = data, loading = false)
+            } catch (t: Throwable) {
+                _uiState.value = ServicesUiState(error = t.localizedMessage)
+            }
+        }
+    }
+}
+
+data class ServicesUiState(
+    val services: List<Service> = emptyList(),
+    val loading: Boolean = false,
+    val error: String? = null
+)

--- a/app/src/main/res/layout/activity_issue_detail.xml
+++ b/app/src/main/res/layout/activity_issue_detail.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/tvDetail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="18sp" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_issues.xml
+++ b/app/src/main/res/layout/activity_issues.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefresh"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_issues.xml
+++ b/app/src/main/res/layout/activity_issues.xml
@@ -1,8 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:title="Issues"
+        android:titleTextColor="@android:color/white"/>
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipeRefresh"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -160,6 +160,16 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"/>
 
+    <FrameLayout
+        android:id="@+id/fragmentContainer"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@id/bottomNav"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
     <!-- ───────── Bottom Navigation ───────── -->
     <com.google.android.material.bottomnavigation.BottomNavigationView
         android:id="@+id/bottomNav"

--- a/app/src/main/res/layout/activity_service_detail.xml
+++ b/app/src/main/res/layout/activity_service_detail.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp">
+
+    <TextView
+        android:id="@+id/tvDetail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="18sp" />
+</LinearLayout>

--- a/app/src/main/res/layout/activity_services.xml
+++ b/app/src/main/res/layout/activity_services.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefresh"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+</LinearLayout>

--- a/app/src/main/res/layout/activity_services.xml
+++ b/app/src/main/res/layout/activity_services.xml
@@ -1,8 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:title="Services"
+        android:titleTextColor="@android:color/white"/>
 
     <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
         android:id="@+id/swipeRefresh"

--- a/app/src/main/res/layout/fragment_issues.xml
+++ b/app/src/main/res/layout/fragment_issues.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/swipeRefresh"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/app/src/main/res/layout/fragment_services.xml
+++ b/app/src/main/res/layout/fragment_services.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/swipeRefresh"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/app/src/main/res/layout/item_issue.xml
+++ b/app/src/main/res/layout/item_issue.xml
@@ -14,14 +14,20 @@
 
         <TextView
             android:id="@+id/tvTitle"
+            style="@style/CC.TitleMedium"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:textStyle="bold" />
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/tvReporter"
+            style="@style/CC.BodySmall"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
 
         <TextView
             android:id="@+id/tvStatus"
+            style="@style/CC.Caption"
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="Status" />
+            android:layout_height="wrap_content" />
     </LinearLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/item_issue.xml
+++ b/app/src/main/res/layout/item_issue.xml
@@ -29,5 +29,47 @@
             style="@style/CC.Caption"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/tvHandler"
+            style="@style/CC.BodySmall"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"/>
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal"
+            android:gravity="center_vertical"
+            android:layout_marginTop="8dp">
+
+            <ImageView
+                android:id="@+id/btnUpvote"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:src="@android:drawable/arrow_up_float" />
+
+            <TextView
+                android:id="@+id/tvUpvotes"
+                style="@style/CC.Caption"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp" />
+
+            <ImageView
+                android:id="@+id/btnDownvote"
+                android:layout_width="24dp"
+                android:layout_height="24dp"
+                android:layout_marginStart="16dp"
+                android:src="@android:drawable/arrow_down_float" />
+
+            <TextView
+                android:id="@+id/tvDownvotes"
+                style="@style/CC.Caption"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginStart="4dp" />
+        </LinearLayout>
     </LinearLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/item_issue.xml
+++ b/app/src/main/res/layout/item_issue.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardElevation="4dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/tvTitle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/tvStatus"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Status" />
+    </LinearLayout>
+</androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/item_service.xml
+++ b/app/src/main/res/layout/item_service.xml
@@ -14,9 +14,22 @@
 
         <TextView
             android:id="@+id/tvName"
+            style="@style/CC.TitleMedium"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/tvDepartment"
+            style="@style/CC.Caption"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/tvDesc"
+            style="@style/CC.BodySmall"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textStyle="bold" />
-
+            android:maxLines="2"
+            android:ellipsize="end" />
     </LinearLayout>
 </androidx.cardview.widget.CardView>

--- a/app/src/main/res/layout/item_service.xml
+++ b/app/src/main/res/layout/item_service.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="8dp"
+    app:cardElevation="4dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/tvName"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+</androidx.cardview.widget.CardView>


### PR DESCRIPTION
## Summary
- add issues data models and mock generator
- implement IssuesActivity with list and detail screens
- add services data models with mock data
- implement ServicesActivity and detail screen
- register new activities in manifest

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c15ca9664832a9aff5e0b3b811fd3