### PR TITLE
Add floating button to create new issues

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,9 @@
             android:name="com.mayank.superapp.issues.IssueDetailActivity"
             android:exported="false" />
         <activity
+            android:name="com.mayank.superapp.issues.AddIssueActivity"
+            android:exported="false" />
+        <activity
             android:name="com.mayank.superapp.services.ServicesActivity"
             android:exported="false" />
         <activity
@@ -45,5 +48,4 @@
             </intent-filter>
         </activity>
     </application>
-
 </manifest>

--- a/app/src/main/java/com/mayank/superapp/issues/AddIssueActivity.kt
+++ b/app/src/main/java/com/mayank/superapp/issues/AddIssueActivity.kt
@@ -1,0 +1,68 @@
+package com.mayank.superapp.issues
+
+import android.os.Bundle
+import android.widget.ArrayAdapter
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import com.mayank.superapp.databinding.ActivityAddIssueBinding
+
+/** Activity for creating a new issue */
+class AddIssueActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityAddIssueBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityAddIssueBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        setSupportActionBar(binding.toolbar)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+
+        setupSpinners()
+
+        binding.btnSubmit.setOnClickListener {
+            submitIssue()
+        }
+    }
+
+    private fun setupSpinners() {
+        binding.spinnerCategory.adapter = ArrayAdapter(
+            this,
+            android.R.layout.simple_spinner_dropdown_item,
+            IssueCategory.values().map { it.name.replace('_', ' ') }
+        )
+
+        binding.spinnerPriority.adapter = ArrayAdapter(
+            this,
+            android.R.layout.simple_spinner_dropdown_item,
+            Priority.values().map { it.name }
+        )
+
+        val handlers = listOf("MP", "MLA", "DM")
+        binding.spinnerHandler.adapter = ArrayAdapter(
+            this,
+            android.R.layout.simple_spinner_dropdown_item,
+            handlers
+        )
+    }
+
+    private fun submitIssue() {
+        val title = binding.etTitle.text.toString().trim()
+        val description = binding.etDescription.text.toString().trim()
+        if (title.isBlank() || description.isBlank()) {
+            Toast.makeText(this, "Please fill all fields", Toast.LENGTH_SHORT).show()
+            return
+        }
+        Toast.makeText(this, "Issue submitted", Toast.LENGTH_SHORT).show()
+        finish()
+    }
+
+    override fun onOptionsItemSelected(item: android.view.MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            finish()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+}

--- a/app/src/main/java/com/mayank/superapp/issues/IssuesActivity.kt
+++ b/app/src/main/java/com/mayank/superapp/issues/IssuesActivity.kt
@@ -7,6 +7,7 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.mayank.superapp.databinding.ActivityIssuesBinding
 import androidx.lifecycle.lifecycleScope
+import com.mayank.superapp.issues.AddIssueActivity
 import kotlinx.coroutines.flow.collectLatest
 
 class IssuesActivity : AppCompatActivity() {
@@ -33,6 +34,10 @@ class IssuesActivity : AppCompatActivity() {
         binding.recyclerView.adapter = adapter
 
         binding.swipeRefresh.setOnRefreshListener { viewModel.loadIssues() }
+
+        binding.fabAddIssue.setOnClickListener {
+            startActivity(Intent(this, AddIssueActivity::class.java))
+        }
 
         lifecycleScope.launchWhenStarted {
             viewModel.uiState.collectLatest { state ->

--- a/app/src/main/java/com/mayank/superapp/issues/IssuesFragment.kt
+++ b/app/src/main/java/com/mayank/superapp/issues/IssuesFragment.kt
@@ -9,6 +9,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import com.mayank.superapp.R
 import com.mayank.superapp.databinding.FragmentIssuesBinding
+import com.mayank.superapp.issues.AddIssueActivity
 import kotlinx.coroutines.flow.collectLatest
 
 class IssuesFragment : Fragment(R.layout.fragment_issues) {
@@ -32,6 +33,10 @@ class IssuesFragment : Fragment(R.layout.fragment_issues) {
         binding.recyclerView.adapter = adapter
 
         binding.swipeRefresh.setOnRefreshListener { viewModel.loadIssues() }
+
+        binding.fabAddIssue.setOnClickListener {
+            startActivity(Intent(requireContext(), AddIssueActivity::class.java))
+        }
 
         lifecycleScope.launchWhenStarted {
             viewModel.uiState.collectLatest { state ->

--- a/app/src/main/res/drawable/ic_add.xml
+++ b/app/src/main/res/drawable/ic_add.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M19,13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"/>
+</vector>

--- a/app/src/main/res/layout/activity_add_issue.xml
+++ b/app/src/main/res/layout/activity_add_issue.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/colorPrimary"
+        android:title="@string/add_issue"
+        android:titleTextColor="@android:color/white"/>
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <LinearLayout
+            android:orientation="vertical"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="16dp">
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Title">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etTitle"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"/>
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="Description"
+                android:layout_marginTop="12dp">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/etDescription"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:minLines="3"
+                    android:gravity="top"/>
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <Spinner
+                android:id="@+id/spinnerCategory"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp" />
+
+            <Spinner
+                android:id="@+id/spinnerPriority"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp" />
+
+            <Spinner
+                android:id="@+id/spinnerHandler"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/btnSubmit"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/submit" />
+
+        </LinearLayout>
+    </ScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/activity_issues.xml
+++ b/app/src/main/res/layout/activity_issues.xml
@@ -13,14 +13,29 @@
         android:title="Issues"
         android:titleTextColor="@android:color/white"/>
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-        android:id="@+id/swipeRefresh"
+    <androidx.coordinatorlayout.widget.CoordinatorLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/recyclerView"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/swipeRefresh"
             android:layout_width="match_parent"
-            android:layout_height="match_parent" />
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+            android:layout_height="match_parent">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/recyclerView"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent" />
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/fabAddIssue"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="16dp"
+            android:contentDescription="@string/add_issue"
+            app:srcCompat="@drawable/ic_add" />
+
+    </androidx.coordinatorlayout.widget.CoordinatorLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_issues.xml
+++ b/app/src/main/res/layout/fragment_issues.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/fragment_issues.xml
+++ b/app/src/main/res/layout/fragment_issues.xml
@@ -1,11 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/swipeRefresh"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <androidx.recyclerview.widget.RecyclerView
-        android:id="@+id/recyclerView"
+    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+        android:id="@+id/swipeRefresh"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
-</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+        android:layout_height="match_parent">
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/recyclerView"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/fabAddIssue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="16dp"
+        android:contentDescription="@string/add_issue"
+        app:srcCompat="@drawable/ic_add" />
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">Civic Connect</string>
-</resources>
+    <string name="add_issue">Add Issue</string>
+    <string name="submit">Submit</string></resources>


### PR DESCRIPTION
## Summary
- add plus FAB in issues screens
- create `AddIssueActivity` with form fields for issue title, description, category, priority and handler
- wire FAB to launch the add issue screen
- include new icon and string resources

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686e5b5338d8832a804914553f60d5e5